### PR TITLE
feat: rename kubeconform-test and add kyverno policies test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,7 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
+    branches: [ 'main' ]
   push:
     branches: [ '*' ]
     tags-ignore: [ '*' ]
@@ -56,7 +57,7 @@ jobs:
       - name: Check compliance
         run: |
           set -euxo pipefail
-          
+
           # mirror kustomize-controller build options
           kustomize_flags=("--load-restrictor=LoadRestrictionsNone")
           kustomize_config="kustomization.yaml"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Setup yq
         uses: mikefarah/yq@557dcb87b8efe786f89a12c09e9046b4753ab72e # v4
-      - name: Setup kubeconform
-        uses: fluxcd/pkg/actions/kubeconform@main
       - name: Setup kustomize
         uses: fluxcd/pkg/actions/kustomize@main
+      - name: Setup kubeconform
+        uses: fluxcd/pkg/actions/kubeconform@main
       - name: Validate schemas
         run: |
           set -euxo pipefail
@@ -41,3 +41,32 @@ jobs:
                 exit 1
               fi
           done
+
+  kyverno-policies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - name: Setup kyverno cli
+        uses: kyverno/action-install-cli@v0.2.0
+        with:
+          release: 'v1.11.0'
+      - name: Check install
+        run: kyverno version
+      - name: Check compliance
+        run: |
+          set -euxo pipefail
+          
+          # mirror kustomize-controller build options
+          kustomize_flags=("--load-restrictor=LoadRestrictionsNone")
+          kustomize_config="kustomization.yaml"
+
+          echo "INFO - Generating kustomize overlays"
+          find . -type f -name $kustomize_config -print0 | while IFS= read -r -d $'\0' file;
+            do
+              echo "INFO - Generating kustomization ${file/%$kustomize_config}"
+              kustomize build "${file/%$kustomize_config}" "${kustomize_flags[@]}" >> resources.yaml
+          done
+
+          echo "INFO - Validating resources against ./policies/"
+          kyverno apply ./policies/ -r resources.yaml --table

--- a/kubernetes/apps/kind/httpbin/deployment-patch.yaml
+++ b/kubernetes/apps/kind/httpbin/deployment-patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  template:
+    spec:
+      containers:
+      - name: istio-proxy
+        image: auto
+        resources:
+          requests:
+            cpu: 50m
+            memory: 112Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: httpbin
+        resources:
+          requests:
+            cpu: 200m
+            memory: 400Mi

--- a/kubernetes/apps/kind/httpbin/kustomization.yaml
+++ b/kubernetes/apps/kind/httpbin/kustomization.yaml
@@ -6,3 +6,9 @@ resources:
   - vs.yaml
 
 namespace: httpbin
+
+patches:
+  - path: ./deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: httpbin

--- a/policies/require-requests-limits.yaml
+++ b/policies/require-requests-limits.yaml
@@ -1,7 +1,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: require-requests-limits
+  name: require-container-requests
   annotations:
     policies.kyverno.io/title: Require Limits and Requests
     policies.kyverno.io/category: Best Practices, EKS Best Practices
@@ -35,5 +35,3 @@ spec:
               requests:
                 memory: "?*"
                 cpu: "?*"
-              limits:
-                memory: "?*"


### PR DESCRIPTION
- Change `kubeconform-test` name to `test`.
- Add `kyverno-policies` job to validate resources against kyverno policies.
- Update workflow to only trigger on PRs against `main`
- Update policy to only check for `resource.requests` since GKE Autopilot automatically makes requests equal to limits.
- Patch `httpbin` deployment with resource requests for it's containers to fix kyverno policy.